### PR TITLE
Add system packages used by the RFDS project

### DIFF
--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -18,11 +18,18 @@ RUN apt-get update \
         postgresql-client \
         pv \
         python-dev \
+        python2.7-dev \
         python3.7-dev \
         screen \
         supervisor \
         tmux \
         vim-tiny \
+        # Extras used by RFDS project
+        binutils \
+        libproj-dev \
+        gdal-bin \
+        ruby-full \
+        git-lfs \
     && rm -rf /var/lib/apt/lists/*
 
 ENV DOCKER_PACKAGE_FILENAME=docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb


### PR DESCRIPTION
The RFDS project would need the `python2.7-dev` system package
and various others (`ruby-full` :sigh:) to be able to use this base
image without re-running an `apt-get update` and `apt-get install`
process.

They might be too much to put into the base image?