### PR TITLE
Add noble image to config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - bionic
           - focal
           - jammy
+          - noble
 
   manifest:
     env:
@@ -86,6 +87,7 @@ jobs:
           - bionic
           - focal
           - jammy
+          - noble
 
   readme:
     needs: manifest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
       - linux
       - self-hosted
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: docker/login-action@v1.9.0
+      - uses: actions/checkout@v4.2.2
+      - uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - uses: docker/build-push-action@v2.4.0
+      - uses: docker/build-push-action@v6.12.0
         with:
           context: .  # See: https://github.com/docker/build-push-action/issues/182#issuecomment-814589666
           file: ${{ matrix.os }}/Dockerfile
@@ -44,7 +44,7 @@ jobs:
       - linux
       - self-hosted
     steps:
-      - uses: docker/login-action@v1.9.0
+      - uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -94,8 +94,8 @@ jobs:
     runs-on:
       - self-hosted
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: peter-evans/dockerhub-description@v2.4.2
+      - uses: actions/checkout@v4.2.2
+      - uses: peter-evans/dockerhub-description@v4.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       context: .
       dockerfile: jammy/Dockerfile
     image: interaction/buildpack-deps:jammy
+  noble:
+    build:
+      context: .
+      dockerfile: noble/Dockerfile
+    image: interaction/buildpack-deps:noble
   latest:
     build:
       context: .

--- a/jammy/Dockerfile
+++ b/jammy/Dockerfile
@@ -39,11 +39,11 @@ RUN apt-get update \
         supervisor \
         tmux \
         vim-tiny \
-    && rm -rf rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # RUN git lfs install --skip-repo --system
 
-ENV DOCKER_VERSION=20.10.17
+ENV DOCKER_VERSION=20.10.24
 RUN --mount=type=cache,id=buildpack-deps-${TARGETARCH},target=/var/lib/apt/lists,sharing=private curl -Ls https://get.docker.com | VERSION="${DOCKER_VERSION}" sh
 
 # Do NOT use dockerize 0.6.1 due to https://github.com/jwilder/dockerize/issues/125

--- a/noble/Dockerfile
+++ b/noble/Dockerfile
@@ -1,0 +1,66 @@
+# syntax = docker/dockerfile:experimental
+
+# Dockerize releases use a different label for arm64 than ${TARGETARCH}, so we need to
+# explicitly set ${DOCKERIZE_ARCH} in a base image for each platform.
+
+FROM buildpack-deps:24.04 as base-amd64
+ENV DOCKERIZE_ARCH=amd64
+ENV TINI_ARCH=amd64
+
+FROM buildpack-deps:24.04 as base-arm64
+ENV DOCKERIZE_ARCH=armhf
+ENV TINI_ARCH=arm64
+
+FROM base-${TARGETARCH}
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
+        atop \
+        apache2-utils \
+        apt-utils \
+        bsdmainutils \
+        dnsutils \
+        gettext  \
+        `# git-lfs` \
+        htop \
+        iputils-ping \
+        jq \
+        less \
+        locales \
+        nano \
+        nginx \
+        postgresql-client \
+        pv \
+        python3-dev \
+        screen \
+        supervisor \
+        tmux \
+        vim-tiny \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV DOCKER_VERSION=27.5.0
+RUN --mount=type=cache,id=buildpack-deps-${TARGETARCH},target=/var/lib/apt/lists,sharing=private curl -Ls https://get.docker.com | VERSION="${DOCKER_VERSION}" sh
+
+# Do NOT use dockerize 0.6.1 due to https://github.com/jwilder/dockerize/issues/125
+ENV DOCKERIZE_VERSION=0.6.0
+RUN wget -nv -O - "https://github.com/jwilder/dockerize/releases/download/v${DOCKERIZE_VERSION}/dockerize-linux-${DOCKERIZE_ARCH}-v${DOCKERIZE_VERSION}.tar.gz" | tar -xz -C /usr/local/bin/ -f -
+
+ENV TINI_VERSION=0.19.0
+RUN wget -nv -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-${TINI_ARCH}"
+RUN chmod +x /usr/local/bin/tini
+
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+# Indicate that we are running in Docker.
+ENV DOCKER=1
+
+# Hide threads, highlight program "basename", enable tree view.
+COPY htoprc /root/.config/htop/htoprc
+
+# Append to bash history.
+ENV PROMPT_COMMAND='history -a'


### PR DESCRIPTION
I went to add python3.12 in` ic-base` but found out I needed a newer image.
I've added noble which is the current LTS and the image builds locally.

I also bumped the patch version of docker in jammy and bumped the action versions.

@aweakley could you check this for me before merging?